### PR TITLE
add benchmark and use RWLock instead of mutex Lock

### DIFF
--- a/async_retry_test.go
+++ b/async_retry_test.go
@@ -612,7 +612,7 @@ func benchmarkDo(tasks int, concurrency int, b *testing.B) {
 			go func() {
 				var dummy int
 				defer wg.Done()
-				for _ = range ch {
+				for range ch {
 					for i := 0; i < 10000; i++ {
 						dummy /= dummy + 1
 					}

--- a/async_retry_test.go
+++ b/async_retry_test.go
@@ -498,11 +498,7 @@ func Test_asyncRetry_DoAndShutdown(t *testing.T) {
 			if err != nil {
 				t.Errorf("Shutdown() error = %v, wantErr %v", err, nil)
 			}
-			select {
-			case err = <-doErr:
-			default:
-				t.Errorf("Do must be finished before Shutdown")
-			}
+			err = <-doErr
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Do() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
Add benchmark. I'm not familiar with Go's benchmark well, I did while referring to https://github.com/golang/go/blob/master/src/context/benchmark_test.go and https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go.
How I write Benchmark could be improved in some way.


I used RWLock instead of MutexLock.
It seems that there was no significant difference between RWLock and MutexLock.
I am not sure why, but I guess that is because lines protected by lock is too small or my benchmark is not  good.

Anyway, in our cases, there is no downsides to use RWLock because our codes don't need write lock unless in shutdown.   


Here is result:

Before:
```
BenchmarkDo10000With2
BenchmarkDo10000With2-8    	       6	 183540896 ns/op
BenchmarkDo10000With4
BenchmarkDo10000With4-8    	      12	  94017395 ns/op
BenchmarkDo10000With8
BenchmarkDo10000With8-8    	      18	  74387720 ns/op
BenchmarkDo10000With16
BenchmarkDo10000With16-8   	      20	  50848883 ns/op
BenchmarkDo10000With32
BenchmarkDo10000With32-8   	      22	  51211708 ns/op
BenchmarkDo10000With64
BenchmarkDo10000With64-8   	      22	  51171929 ns/op
```

After:
```
BenchmarkDo10000With2-8    	       6	 173679699 ns/op
BenchmarkDo10000With4
BenchmarkDo10000With4-8    	      13	  88554217 ns/op
BenchmarkDo10000With8
BenchmarkDo10000With8-8    	      22	  50705426 ns/op
BenchmarkDo10000With16
BenchmarkDo10000With16-8   	      22	  51133949 ns/op
BenchmarkDo10000With32
BenchmarkDo10000With32-8   	      22	  50915241 ns/op
BenchmarkDo10000With64
BenchmarkDo10000With64-8   	      22	  51746030 ns/op
```