### PR TITLE
change default timeout from 10s to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Async-retry controls asynchronous retries in Go, and can be shutdown gracefully.
 Main features of Async-retry are
 * Disable cancellation of context passed to function as an argument
 * Keep value of context passed to function as an argument
-* Set timeout(default 10s) for each function call
+* Set timeout for each function call
 * Recover from panic
 * Control retry with delegating to https://github.com/avast/retry-go
 * Gracefully shutdown

--- a/options.go
+++ b/options.go
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	timeout:                         time.Second * 10,
+	timeout:                         0,
 	context:                         context.Background(),
 	cancelWhenShutdown:              false,
 	cancelWhenConfigContextCanceled: true,


### PR DESCRIPTION
Default timeout 10s is good for us, but default timeout setting is counter-intuitive for external users.
I think we should not set timeout at default.