### PR TITLE
fix timeout bug

### DIFF
--- a/async_retry.go
+++ b/async_retry.go
@@ -94,9 +94,9 @@ func (a *asyncRetry) call(ctx context.Context, f RetryableFunc, config *Config) 
 	return retry.Do(
 		func() error {
 			if config.timeout > 0 {
-				var timeoutCancel context.CancelFunc
-				ctx, timeoutCancel = context.WithTimeout(ctx, config.timeout)
+				timeoutCtx, timeoutCancel := context.WithTimeout(ctx, config.timeout)
 				defer timeoutCancel()
+				return f(timeoutCtx)
 			}
 			return f(ctx)
 		},

--- a/async_retry_test.go
+++ b/async_retry_test.go
@@ -124,9 +124,16 @@ func Test_asyncRetry_Do(t *testing.T) {
 			name: "Timeout set correctly for each try",
 			args: args{
 				f: func(ctx context.Context) error {
+					started := time.Now()
 					counter++
 					select {
 					case <-ctx.Done():
+						// Since the timeout for this test case is 10 msec,
+						// even considering the error of the measurement,
+						// at least 9 msec should have elapsed by the time `ctx.Done()` is received.
+						if time.Since(started) < (9 * time.Millisecond) {
+							return Unrecoverable(fmt.Errorf("timeout is too fast"))
+						}
 						if counter < 3 {
 							return fmt.Errorf("timeout")
 						}


### PR DESCRIPTION
Fixed a problem related to timeout config:

The `ctx` was being overwritten when the timeout config value was set.
This could result in an immediate timeout on the next retry.

Fixed to not overwrite ctx when timeout config value was set.